### PR TITLE
Use script-scoped Servers collection for new servers

### DIFF
--- a/Tilepinger.ps1
+++ b/Tilepinger.ps1
@@ -264,17 +264,17 @@ function Add-Server([string]$name,[string]$hostStr) {
     if ([string]::IsNullOrWhiteSpace($hostStr)) { return }
     if ([string]::IsNullOrWhiteSpace($name)) { $name = $hostStr }
     if (-not (Exists-Server $name $hostStr)) {
-        $Servers += @{ name=$name; host=$hostStr }
+        $script:Servers += @{ name=$name; host=$hostStr }
         $tile = New-Tile @{ name=$name; host=$hostStr }
         $ui[$tile.key] = $tile
         [void]$grid.Children.Add($tile.Border)
         Update-ServerStatus $tile.server
-        Save-Servers $Servers
+        Save-Servers $script:Servers
         Reflow-Grid; Refresh-ListUI
     }
 }
 function Add-ServersBulk([string[]]$hosts) {
-    $i = $Servers.Count + 1
+    $i = $script:Servers.Count + 1
     foreach($h in $hosts){
         $h = $h.Trim()
         if (-not $h) { continue }


### PR DESCRIPTION
## Summary
- Ensure `Add-Server` uses the script-scoped `Servers` collection
- Fix bulk addition logic to reference script-scoped server list

## Testing
- `pwsh -NoProfile -File ./Tilepinger.ps1` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6aa6234c8325b32ba00c8b82df64